### PR TITLE
Move gcc installation to README, seperate compilation and installation in Makefile, and add clean to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,16 @@
-# Check for updates and install GCC compiler.
-gcc:
-	sudo apt update && sudo apt install build-essential
+# Compile coffeetch
+all: src/coffeetch.c
+	gcc src/coffeetch.c -o coffeetch
 
+clean:
+	rm -f coffeetch
 
 # Install coffeetch
+# This will move coffeetch to the /usr/bin directory
 install:
-	gcc src/coffeetch.c -o src/coffeetch && sudo mv src/coffeetch /usr/bin/
-
+	sudo cp coffeetch /usr/bin
 
 # Uninstall coffeetch
 # This will delete coffeetch from the /usr/bin/ directory.
 uninstall:
-	sudo rm coffeetch /usr/bin/coffeetch
+	sudo rm /usr/bin/coffeetch

--- a/README.md
+++ b/README.md
@@ -20,24 +20,23 @@ If there is some incorrect system information shown in ```coffeetch```, open an 
 <br>
 
 ## Configuration
+
+Your distro may or may not come with a C compiler called **GCC**, which is required to build ```coffeetch```. You can check if you have it by running ```gcc --version``` in a terminal. If it outputs GCC version information, you can skip to installing coffeetch. If not, follow the instructions to install the compiler. 
+
+**If you do not have a compiler**:
+| Steps | Commands |
+|-------|----------|
+| Download compiler (Debian/Ubuntu) | $```sudo apt update && sudo apt install build-essential``` |
+| Download compiler (Arch) | $```sudo pacman -Sy && sudo pacman -S base-devel``` |
+
 **Install:**
 | Steps | Commands |
 |-------|----------|
 | Download coffeetch | $ ```git clone https://github.com/clieg/coffeetch``` |
 | Go to coffeetch directory | $ ```cd coffeetch``` |
-| Install coffeetch | $ ```make install``` |
+| Compile coffeetch | $ ```make``` |
+| Install coffeetch | $```make install``` |
 | Run coffeetch | $ ``` coffeetch ``` |
-
-
-**If you do not have a compiler**:
-| Steps | Commands |
-|-------|----------|
-| Download coffeetch | $ ```git clone https://github.com/clieg/coffeetch``` |
-| Go to coffeetch directory | $ ```cd coffeetch``` |
-| Download compiler | $ ```make gcc``` |
-| Install coffeetch | $ ```make install``` |
-| Run coffeetch | $ ``` coffeetch ``` |
-
 
 **Uninstall:**
 | Steps | Commands |


### PR DESCRIPTION
 - Moves gcc installation to the README
 - Separates the compilation and installation in the Makefile
 - Adds the `clean` command to the Makefile